### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,8 +1,8 @@
+ Here is the complete code with the vulnerability fixed:
+
 package com.scalesec.vulnado;
 
-import java.sql.Connection;
-import java.sql.Statement;
-import java.sql.ResultSet;
+import java.sql.*;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -13,7 +13,7 @@ public class User {
   public String id, username, hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
-    this.id = id;
+    this.id = id; 
     this.username = username;
     this.hashedPassword = hashedPassword;
   }
@@ -32,7 +32,7 @@ public class User {
         .parseClaimsJws(token);
     } catch(Exception e) {
       e.printStackTrace();
-      throw new Unauthorized(e.getMessage());
+      throw new Unauthorized(e.getMessage()); 
     }
   }
 
@@ -42,11 +42,13 @@ public class User {
     try {
       Connection cxn = Postgres.connection();
       stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
-
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      
+      // Use a prepared statement to avoid SQL injection
+      String query = "SELECT * FROM users WHERE username = ? LIMIT 1";
+      PreparedStatement pstmt = cxn.prepareStatement(query);
+      pstmt.setString(1, un);
+      
+      ResultSet rs = pstmt.executeQuery();
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");
@@ -58,7 +60,7 @@ public class User {
       e.printStackTrace();
       System.err.println(e.getClass().getName()+": "+e.getMessage());
     } finally {
-      return user;
+      return user; 
     }
   }
 }


### PR DESCRIPTION
 Here is the detailed Pull Request review for commit abd0e18cc59750c7af4310ffdfa3347d61bd0ff6:

![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for abd0e18cc59750c7af4310ffdfa3347d61bd0ff6

**Descrição:**
This commit fixes a SQL injection vulnerability in the User.fetch method by switching from using a Statement to a PreparedStatement. 

**Sumario:**
- src/main/java/com/scalesec/vulnado/User.java - Switched from using Statement to PreparedStatement to prevent SQL injection in User.fetch method.

**Recomendações:**
- Review the prepared statement syntax and parameter binding to ensure no mistakes were made. 
- Add validation checks on user input parameters before passing to prepared statement.
- Write unit tests to validate fix and prevent regressions.

**Explicação de Vulnerabilidades:**
The previous code was vulnerable to SQL injection because user input was directly inserted into the SQL query without any validation or sanitization. This could allow an attacker to modify the query logic or access unauthorized data. The fix uses a prepared statement and binds the user input as a parameter, which automatically escapes it correctly.

Here is an example of how SQL injection could be used before:

```
// Attacker passes this as username
String un = "' OR 1=1 --"; 

String query = "select * from users where username = '" + un + "' limit 1";

// Query becomes:
select * from users where username = '' OR 1=1 --' limit 1
```

By switching to prepared statements, the user input is handled safely by the driver and cannot modify the query structure.