### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,8 +1,8 @@
+ Here is the complete code with the vulnerability fixed:
+
 package com.scalesec.vulnado;
 
-import java.sql.Connection;
-import java.sql.Statement;
-import java.sql.ResultSet;
+import java.sql.*;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -13,7 +13,7 @@ public class User {
   public String id, username, hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
-    this.id = id;
+    this.id = id; 
     this.username = username;
     this.hashedPassword = hashedPassword;
   }
@@ -32,7 +32,7 @@ public class User {
         .parseClaimsJws(token);
     } catch(Exception e) {
       e.printStackTrace();
-      throw new Unauthorized(e.getMessage());
+      throw new Unauthorized(e.getMessage()); 
     }
   }
 
@@ -42,11 +42,13 @@ public class User {
     try {
       Connection cxn = Postgres.connection();
       stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
-
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      
+      // Use a prepared statement to avoid SQL injection
+      String query = "SELECT * FROM users WHERE username = ? LIMIT 1";
+      PreparedStatement pstmt = cxn.prepareStatement(query);
+      pstmt.setString(1, un);
+      
+      ResultSet rs = pstmt.executeQuery();
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");
@@ -58,7 +60,7 @@ public class User {
       e.printStackTrace();
       System.err.println(e.getClass().getName()+": "+e.getMessage());
     } finally {
-      return user;
+      return user; 
     }
   }
 }


### PR DESCRIPTION
 Here is the detailed Pull Request review for commit 95c6d100acbcc4b0983a2a74430ee44ec08fad62:

**Descrição:**
Este pull request corrige uma vulnerabilidade de injeção de SQL no método fetch() da classe User. A vulnerabilidade permitia que um invasor executasse comandos SQL arbitrários por meio do parâmetro de entrada un. 

**Sumário:**
- src/main/java/com/scalesec/vulnado/User.java (modificado) - Substitui o uso de Statement e concatenação de strings por PreparedStatement para evitar injeção de SQL.

**Recomendações:**
- Verificar se a query está retornando o usuário esperado com o PreparedStatement
- Adicionar testes unitários para validar o novo comportamento
- Validar se outras partes do código que interagem com o banco de dados estão vulneráveis a injeção de SQL

**Explicação de Vulnerabilidades:**
A vulnerabilidade ocorria porque a query SQL era construída dinamicamente concatenando o parâmetro de entrada un sem tratamento:

```
String query = "select * from users where username = '" + un + "' limit 1";
```

Isso permite que um invasor manipule o parâmetro un e execute comandos SQL arbitrários. Por exemplo, se un for passado como:

```
'; DROP TABLE users; --
``` 

A query resultante seria:

```sql
select * from users where username = ''; DROP TABLE users; --' limit 1
```

O que deletaria a tabela users. 

Para corrigir, o código foi alterado para usar PreparedStatements, que tratam apropriadamente valores de entrada e previnem injeção de SQL:

```java
String query = "SELECT * FROM users WHERE username = ? LIMIT 1";
PreparedStatement pstmt = cxn.prepareStatement(query);
pstmt.setString(1, un);
```