### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/Postgres.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Postgres.java
+++ b/src/main/java/com/scalesec/vulnado/Postgres.java
@@ -1,8 +1,9 @@
+ Here is the complete code with the vulnerability fixed:
+
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.PreparedStatement;
@@ -28,6 +29,7 @@ public class Postgres {
         }
         return null;
     }
+    
     public static void setup(){
         try {
             System.out.println("Setting up Database...");
@@ -58,33 +60,17 @@ public class Postgres {
         }
     }
 
-    // Java program to calculate MD5 hash value
-    public static String md5(String input)
-    {
-        try {
-
-            // Static getInstance method is called with hashing MD5
-            MessageDigest md = MessageDigest.getInstance("MD5");
-
-            // digest() method is called to calculate message digest
-            //  of an input digest() return array of byte
-            byte[] messageDigest = md.digest(input.getBytes());
-
-            // Convert byte array into signum representation
-            BigInteger no = new BigInteger(1, messageDigest);
-
-            // Convert message digest into hex value
-            String hashtext = no.toString(16);
-            while (hashtext.length() < 32) {
-                hashtext = "0" + hashtext;
-            }
-            return hashtext;
+    // Use SHA-256 instead of weak MD5
+    public static String hash(String input) throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        byte[] hash = md.digest(input.getBytes());
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : hash) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) hexString.append('0');
+            hexString.append(hex);
         }
-
-        // For specifying wrong message digest algorithms
-        catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
+        return hexString.toString();
     }
 
     private static void insertUser(String username, String password) {
@@ -94,7 +80,10 @@ public class Postgres {
           pStatement = connection().prepareStatement(sql);
           pStatement.setString(1, UUID.randomUUID().toString());
           pStatement.setString(2, username);
-          pStatement.setString(3, md5(password));
+          
+          // Hash password with SHA-256 instead of MD5
+          pStatement.setString(3, hash(password));
+          
           pStatement.executeUpdate();
        } catch(Exception e) {
          e.printStackTrace();


### PR DESCRIPTION
 Here is the detailed Pull Request review for commit 5bfb6709f7528dd922cda016eb3f284cd3f1f75d:

![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for 5bfb6709f7528dd922cda016eb3f284cd3f1f75d

**Descrição:**
This commit updates the Postgres.java file to fix a vulnerability in password hashing. It replaces the weak MD5 hash with a more secure SHA-256 hash.

**Sumário:**
- src/main/java/com/scalesec/vulnado/Postgres.java (modified) - Replaces MD5 password hashing with more secure SHA-256. Removes MD5 hashing code and adds SHA-256 hash function. Updates insertUser method to use new hash function.

**Recomendações:**
- Review new hash function implementation for correctness. 
- Verify hash output matches expected SHA-256 format.
- Test login with existing hashed passwords to ensure backwards compatibility.
- Add tests for new hash function.
- Consider additional enhancements like salting hashes.

**Explicação de Vulnerabilidades:**
The previous MD5 based password hashing was vulnerable to collision attacks. MD5 is no longer considered secure for password hashing. 

An example fix is to replace it with a more secure password hashing algorithm like SHA-256, and update the code that generates password hashes. The commit implements this fix.

Some example code for SHA-256 password hashing in Java:

```java
MessageDigest md = MessageDigest.getInstance("SHA-256");
byte[] hash = md.digest(password.getBytes()); 
// Store hash in db
```

This helps mitigate the weaknesses in MD5 for password hashing.