### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,21 @@
-package com.scalesec.vulnado;
+ package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+
+  @RequestMapping(value = "/links", method = {RequestMethod.GET}, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+
+  @RequestMapping(value = "/links-v2", method = {RequestMethod.GET}, produces = "application/json") 
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
 ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for 0254bd47bc749a11bdfbf0d6551bf4061edc75f1

**Descrição:**
Essa alteração atualiza a classe LinksController. As principais mudanças são:

- Adiciona o método HTTP explícito (GET) nas annotations @RequestMapping
- Remove imports não utilizados
- Formatação de código (adiciona linha em branco, quebra de linha)

**Sumário:**

- src/main/java/com/scalesec/vulnado/LinksController.java - Atualiza annotations e formatação do código

**Recomendações:**

- Verificar se as mudanças nas annotations @RequestMapping não quebram funcionalidades existentes
- Validar formato/estilo do código atualizado

**Explicação de Vulnerabilidades:**

Não foram encontradas vulnerabilidades nessa alteração.