### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,19 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.logging.Logger;
+import java.util.logging.Level;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = Logger.getLogger(User.class.getName());
+  private String id;
+  private String username;
+  private String hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,47 +21,61 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() {
+    return id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getHashedPassword() {
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact();
   }
 
   public static void assertAuth(String secret, String token) {
     try {
       SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-      Jwts.parser()
-        .setSigningKey(key)
-        .parseClaimsJws(token);
+      Jwts.parser().setSigningKey(key).parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.log(Level.SEVERE, e.getMessage(), e);
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null;
     User user = null;
-    try {
-      Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
-
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
-      if (rs.next()) {
-        String user_id = rs.getString("user_id");
-        String username = rs.getString("username");
-        String password = rs.getString("password");
-        user = new User(user_id, username, password);
+    try (Connection cxn = Postgres.connection()) {
+      LOGGER.info("Opened database successfully");
+      String query = "select * from users where username = ? limit 1";
+      stmt = cxn.prepareStatement(query);
+      stmt.setString(1, un);
+      LOGGER.info(stmt.toString());
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next()) {
+          String userId = rs.getString("user_id");
+          String username = rs.getString("username");
+          String password = rs.getString("password");
+          user = new User(userId, username, password);
+        }
       }
-      cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
+      LOGGER.log(Level.SEVERE, e.getClass().getName()+": "+e.getMessage(), e);
     } finally {
-      return user;
+      if (stmt != null) {
+        try {
+          stmt.close();
+        } catch (Exception e) {
+          LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        }
+      }
     }
+    return user;
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 1f58b2de5d4eea03fbf6ba85f381ae24cb67af79
**Descrição:** Este pull request apresenta várias melhorias e refatorações no arquivo User.java. A maioria das mudanças visa melhorar a qualidade do código e aumentar a segurança da aplicação.

**Sumário:** 

- User.java (modificado)
  - Trocado `java.sql.Statement` por `java.sql.PreparedStatement` para evitar ataques de injeção SQL.
  - Adicionado `java.util.logging.Logger` para melhorar o logging de erros.
  - Alterado o modificador de acesso dos atributos de `public` para `private` e adicionado métodos getters correspondentes para seguir o princípio de encapsulamento.
  - Refatorado o método `assertAuth` para usar o Logger em vez de imprimir o stack trace diretamente.
  - Refatorado o método `fetch` para usar `try-with-resources`, melhorando o gerenciamento de recursos.
  - Removido a linha em branco no final do arquivo.

**Recomendações:** É recomendável verificar se todas as alterações funcionam conforme esperado e se cumprem os requisitos de segurança e qualidade do código. Em particular, o uso de `PreparedStatement` deve ser testado para garantir que não haja problemas de injeção SQL. Além disso, a mudança para o uso de Logger deve ser verificada para garantir que todas as mensagens de log estão sendo corretamente registradas.

**Explicação de Vulnerabilidades:** Não foram encontradas novas vulnerabilidades neste pull request. A mudança de `java.sql.Statement` para `java.sql.PreparedStatement` é uma correção de segurança importante, pois ajuda a prevenir ataques de injeção SQL. Esta vulnerabilidade ocorre quando um invasor é capaz de inserir instruções SQL maliciosas em uma consulta, o que pode levar a vários problemas de segurança, como a divulgação de dados sensíveis ou a manipulação de dados no banco de dados. A utilização de `PreparedStatement` resolve este problema, pois garante que todos os parâmetros da consulta sejam devidamente escapados, impedindo a execução de instruções SQL maliciosas.