### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,45 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @CrossOrigin(origins = "*") //TBD
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @CrossOrigin(origins = "*") //TBD
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @CrossOrigin(origins = "*") //TBD
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public void setBody(String body) {
+    this.body = body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 62d580dacee110cfb5c831103c871b1d49d327e4

**Descrição:** Este Pull Request consiste em atualizações no arquivo CommentsController.java que envolvem a mudança de métodos específicos do controlador para métodos anotados de forma mais simplificada. Adicionalmente, os campos `username` e `body` na classe `CommentRequest` foram alterados para privados, com métodos get e set correspondentes sendo adicionados.

**Sumario:** 

- src/main/java/com/scalesec/vulnado/CommentsController.java (modificado)
  - Substituição das anotações @RequestMapping por @GetMapping, @PostMapping e @DeleteMapping correspondentes
  - A classe `CommentRequest` agora tem `username` e `body` como campos privados, com métodos get e set correspondentes

**Recomendações:** 

- As alterações parecem estar em ordem, mas vale a pena verificar se a mudança de @RequestMapping para anotações mais específicas (@GetMapping, @PostMapping, @DeleteMapping) não afeta a funcionalidade existente de qualquer maneira.
- A mudança para tornar os campos `username` e `body` privados em `CommentRequest` e a adição de métodos get e set é uma boa prática em Java para encapsulamento de dados. No entanto, certifique-se de que isso não afete a funcionalidade existente onde a classe `CommentRequest` é usada.
- Note que @CrossOrigin(origins = "*") //TBD é usado, o que permite solicitações de qualquer origem. Isso pode levar a problemas de segurança e deve ser substituído por uma lista de domínios confiáveis. 

**Explicação de Vulnerabilidades:** 

- A anotação @CrossOrigin(origins = "*") é usada, o que é uma má prática de segurança, pois permite solicitações de qualquer domínio. Isso pode permitir ataques de Cross-Origin Resource Sharing (CORS) de domínios não confiáveis. É recomendável substituir "*" por uma lista de domínios confiáveis. Por exemplo, @CrossOrigin(origins = "http://dominioconfiavel.com").
