### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,19 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 2d079fc9e562c9626e73bc0c14c4c1a2193bc010

**Descrição:** Neste pull request, foi feita uma atualização no arquivo `src/main/java/com/scalesec/vulnado/LinksController.java`. As principais mudanças incluem a remoção de algumas importações não utilizadas e a alteração do mapeamento de solicitação para os métodos `links` e `linksV2` para especificamente aceitar solicitações GET.

**Sumário:** 

- Arquivo `src/main/java/com/scalesec/vulnado/LinksController.java` (modificado) - Removidas as importações para `org.springframework.boot.*`, `org.springframework.http.HttpStatus` e `java.io.Serializable` que não estavam sendo usadas. Também foi atualizada a anotação `@RequestMapping` para os métodos `links` e `linksV2` para especificamente aceitar solicitações GET.

**Recomendações:** Recomendo testar o funcionamento dos métodos atualizados `links` e `linksV2` com diferentes URLs para garantir que eles ainda estão funcionando conforme o esperado após a atualização. 

Como sempre, é importante garantir que todas as alterações cumpram com os padrões de codificação e não introduzam novas vulnerabilidades de segurança.