### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,23 +1,21 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  
+  @RequestMapping(value = "/links", method=RequestMethod.GET, produces = "application/json")
+  public List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+  
+  @RequestMapping(value = "/links-v2", method=RequestMethod.GET, produces = "application/json")
+  public List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 570624f305ef25a741ed3caff303a6ed57da5fbc

**Descrição:** As alterações realizadas nesse Pull Request visam refatorar e otimizar o código do controlador de links, melhorando a legibilidade e a manutenção do código. Além disso, os métodos agora seguem o princípio do RESTful, onde especificamos o tipo de método HTTP na anotação `@RequestMapping`.

**Sumario:** 
- `src/main/java/com/scalesec/vulnado/LinksController.java` (modificado): 
  - Importações desnecessárias foram removidas.
  - Espaços em branco adicionados para melhorar a legibilidade.
  - Os métodos `links` e `linksV2` agora são públicos e especificam o método HTTP GET em suas anotações `@RequestMapping`.
  - As quebras de linha foram adicionadas ao final de cada método para melhorar a legibilidade.
  
**Recomendações:** 
- Por favor, verifique se a funcionalidade dos métodos `links` e `linksV2` permaneceu a mesma após as alterações.
- Execute testes para garantir que os métodos `links` e `linksV2` estejam retornando os resultados esperados.
- Verifique o código para garantir que nenhuma importação necessária foi removida erroneamente.

Não foram encontradas vulnerabilidades atuais ou corrigidas neste Pull Request.