### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,14 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 public class User {
-  public String id, username, hashedPassword;
+  private String id, username, hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,10 +16,21 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() {
+    return this.id;
+  }
+
+  public String getUsername() {
+    return this.username;
+  }
+
+  public String getHashedPassword() {
+    return this.hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact();
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +40,26 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null;
     User user = null;
-    try {
-      Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
-
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+    try (Connection cxn = Postgres.connection()) {
+      stmt = cxn.prepareStatement("select * from users where username = ? limit 1");
+      stmt.setString(1, un);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id");
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
-      cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
-    } finally {
-      return user;
+      throw new Unauthorized(e.getMessage());
     }
+    return user;
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o commit 2ec1501e39799c3abe9221f863a6930c3519bc07
**Descrição:** Nesse Pull Request, foi feita uma atualização no arquivo User.java. As alterações estão principalmente relacionadas com a segurança e a eficiência do código.

**Sumario:** 
- Arquivo src/main/java/com/scalesec/vulnado/User.java (alterado)
  - Os campos 'id', 'username', 'hashedPassword' foram alterados de 'public' para 'private' e foram criados métodos getters para esses campos. Isso é uma prática de segurança para evitar o acesso direto a esses campos.
  - A declaração e inicialização da variável 'stmt' foram modificadas para usar 'PreparedStatement' em vez de 'Statement', que é uma prática recomendada para prevenir a injeção de SQL.
  - O bloco 'try-catch' foi modificado para usar 'try-with-resources', que garante que cada recurso é fechado no final da instrução.
  - Removido o 'printStackTrace' do bloco 'catch' e adicionado o lançamento de uma exceção 'Unauthorized' com a mensagem de erro. Isso proporciona melhor manipulação de erros e também é uma prática recomendada para evitar a exposição de detalhes sensíveis do erro.
  - A consulta SQL foi alterada para usar parâmetros, que é uma prática recomendada para prevenir a injeção de SQL.

**Recomendações:** 
- É recomendado que o revisor confirme se todas as alterações estão de acordo com as práticas recomendadas de segurança e eficiência.
- Sugiro que sejam feitos testes para garantir que as alterações não afetam a funcionalidade do código. 

**Explicação de Vulnerabilidades:** 
- A mudança de 'public' para 'private' nos campos 'id', 'username', 'hashedPassword' e a adição de métodos getters ajuda a evitar o acesso direto a esses campos, que pode ser uma vulnerabilidade de segurança.
- A mudança de 'Statement' para 'PreparedStatement' ajuda a prevenir a injeção de SQL, que é uma séria vulnerabilidade de segurança. 
- O uso de 'try-with-resources' garante que todos os recursos são fechados no final da instrução, prevenindo assim vazamentos de recursos.
- O lançamento de uma exceção 'Unauthorized' no bloco 'catch', em vez de imprimir o 'stackTrace', ajuda a evitar a exposição de detalhes sensíveis de erros, que pode ser uma vulnerabilidade de segurança.
- A mudança na consulta SQL para usar parâmetros também ajuda a prevenir a injeção de SQL.