### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/Cowsay.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -2,12 +2,24 @@ package com.scalesec.vulnado;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.logging.Logger;
+import java.util.logging.Level;
 
 public class Cowsay {
+  private static final Logger LOGGER = Logger.getLogger(Cowsay.class.getName());
+  
+  // Private constructor to prevent instantiation
+  private Cowsay() {
+    throw new IllegalStateException("Cowsay class");
+  }
+
   public static String run(String input) {
     ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
+    // Sanitize the input to prevent command injection
+    String sanitizedInput = input.replaceAll("['\"]", "");
+    String cmd = "/usr/games/cowsay '" + sanitizedInput + "'";
+    // Use logger instead of System.out.println
+    LOGGER.log(Level.INFO, cmd);
     processBuilder.command("bash", "-c", cmd);
 
     StringBuilder output = new StringBuilder();
@@ -21,7 +33,7 @@ public class Cowsay {
         output.append(line + "\n");
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.log(Level.SEVERE, e.getMessage(), e);
     }
     return output.toString();
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 17fd037957a90ac84b3e2ede7d0afe9615ac67ba

**Descrição:** Este Pull Request introduz melhorias de segurança e padrões de codificação para a classe Cowsay.java. A entrada para o comando 'cowsay' agora é higienizada para evitar injeções de comando e a saída é registrada usando um logger em vez de System.out.println. Além disso, a classe Cowsay agora é efetivamente inacessível, pois seu construtor é privado.

**Sumário:** 

- src/main/java/com/scalesec/vulnado/Cowsay.java (modificado) - Adicionado Logger para registrar informações e erros. A entrada para o comando 'cowsay' agora é higienizada para evitar injeções de comando. O construtor da classe é privado para prevenir a instância da classe.

**Recomendações:** Verifique se a higienização da entrada é suficiente para prevenir todas as formas possíveis de injeção de comando. Além disso, é recomendado testar o registro para garantir que todas as informações e erros sejam registrados corretamente.

**Explicação de Vulnerabilidades:** A injeção de comando é uma vulnerabilidade que permite a um invasor executar comandos arbitrários no sistema host. Ao higienizar a entrada para o comando 'cowsay', esta atualização ajuda a prevenir a injeção de comando. A vulnerabilidade foi corrigida substituindo a entrada do usuário por uma versão higienizada que remove caracteres que podem permitir a injeção de comando.