### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger;
 
 public class LinkLister {
+
+  private static final Logger logger = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // Private constructor to hide the implicit public one.
+  }
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 44fb8ed90c6c353aa20b71e8b12487aacc9428b4

**Descrição:** 

Neste PR, foram feitas várias alterações na classe LinkLister.java. Um objeto Logger foi adicionado, uma nova função privada de construtor foi adicionada, e a maneira como as mensagens de host são manipuladas foi alterada de System.out.println para logger.info.

**Sumário:**

- Arquivo src/main/java/com/scalesec/vulnado/LinkLister.java (modificado): 
  - Adicionado objeto Logger para registrar mensagens de log.
  - Adicionado um novo construtor privado para esconder o construtor público implícito.
  - Alterado o método de exibição de mensagens de host de System.out.println para logger.info.

**Recomendações:** 

O revisor deve verificar se a adição do objeto Logger e a alteração da exibição das mensagens de host estão corretas e funcionando como esperado. Além disso, a adição do construtor privado pode ter implicações que precisam ser verificadas - como a classe é usada e se a adição deste construtor privado não quebra nenhuma funcionalidade existente. 

Por fim, o revisor deve garantir que as melhores práticas de codificação foram seguidas, incluindo a formatação adequada do código e a adição de comentários úteis onde necessário.