### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,19 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 465e7501b208dc41c23b6de5dbbced53366e6a07
**Descrição:** Este pull request traz uma atualização no arquivo `LinksController.java` localizado em `src/main/java/com/scalesec/vulnado/`. A principal alteração foi a mudança no método de requisição dos endpoints `/links` e `/links-v2` de qualquer tipo para especificamente GET. Além disso, houve a remoção de alguns imports que estavam sendo inutilizados.

**Sumário:** 
- `src/main/java/com/scalesec/vulnado/LinksController.java`: 
  - Mudança no método de requisição dos endpoints `/links` e `/links-v2` para GET.
  - Remoção dos imports `org.springframework.boot.*`, `org.springframework.http.HttpStatus` e `java.io.Serializable` que não estavam sendo utilizados.

**Recomendações:** 
- Recomendo que seja feito um teste para garantir que a mudança no método de requisição dos endpoints não afete o comportamento esperado da aplicação.
- Além disso, vale a pena conferir se a remoção dos imports realmente não interfere em nada no código, mesmo que eles pareçam não estar sendo utilizados.

**Explicação de Vulnerabilidades:** Não foram identificadas vulnerabilidades nesse commit.