### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+
+  // Add private constructor to hide the implicit public one.
+  private LinkLister() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +34,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 1eae81a2cd6c4fd056f6780241d990cf54b2a48e
                                                **Descrição:** O arquivo `LinkLister.java` foi modificado para melhorar o controle de logs e a segurança. Um Logger foi adicionado para substituir a impressão padrão do sistema. Além disso, um construtor privado foi adicionado para a classe `LinkLister` para evitar que ela seja instanciada desnecessariamente, já que é uma classe de utilitários.
                                                \n
                                                **Sumario:** - Arquivo `LinkLister.java` (modificado) - Foi adicionado um Logger para melhorar o controle de logs, substituindo a impressão padrão do sistema. Um construtor privado foi adicionado para evitar instancias desnecessárias da classe `LinkLister`.
                                                \n
                                                **Recomendações:** Recomendo que o revisor verifique se a adição do Logger foi feita corretamente e se está funcionando como esperado. Além disso, verificar se a adição do construtor privado não causou nenhum efeito colateral indesejado.
                                                \n