### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method=RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method=RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 4b6904c8b24f3dd813db64838828ebc8d1197fdb
**Descrição:** Este Pull Request atualiza o arquivo 'LinksController.java' na pasta 'src/main/java/com/scalesec/vulnado/'. As mudanças incluem a remoção de algumas importações não utilizadas, a adição de RequestMethod.GET nos métodos RequestMapping, e a remoção de uma linha vazia no final do arquivo.

**Sumario:**

- Arquivo modificado: src/main/java/com/scalesec/vulnado/LinksController.java 

   - Importações não utilizadas removidas: 'org.springframework.boot.*', 'org.springframework.http.HttpStatus', e 'java.io.Serializable'
   
   - Adicionado RequestMethod.GET nas anotações @RequestMapping para os métodos 'links' e 'links-v2'. Isso especifica que esses métodos devem ser acessados através de uma solicitação GET.
   
   - Removida linha vazia no final do arquivo.

**Recomendações:** Por favor, assegure-se que a remoção das importações não afeta a funcionalidade do aplicativo. Teste a aplicação com solicitações GET para '/links' e '/links-v2' e observe se o comportamento é o esperado.